### PR TITLE
Useless $api_key

### DIFF
--- a/steamauth/steamauth.php
+++ b/steamauth/steamauth.php
@@ -2,7 +2,6 @@
 ob_start();
 session_start();
 require ('openid.php');
-$api_key = ""; //Insert API Key here!
 
 function logoutbutton() {
     echo "<form action=\"steamauth/logout.php\" method=\"post\"><input value=\"Logout\" type=\"submit\" /></form>"; //logout button


### PR DESCRIPTION
Noted in Issue #19
Useless API key in steamauth.php
$api_key isn't used in steamauth.php, no need for it.
