### PR TITLE
SteamAuthentication update to use cURL

### DIFF
--- a/steamauth/settings.php
+++ b/steamauth/settings.php
@@ -9,4 +9,17 @@ $steamauth['loginpage'] = ""; // Page to redirect to after a successfull login (
 if (empty($steamauth['apikey'])) {die("<div style='display: block; width: 100%; background-color: red; text-align: center;'>SteamAuth:<br>Please supply an API-Key!</div>");}
 if (empty($steamauth['domainname'])) {$steamauth['domainname'] = "localhost";}
 if ($steamauth['buttonstyle'] != "small" and $steamauth['buttonstyle'] != "large") {$steamauth['buttonstyle'] = "large_no";}
+
+function url_get_contents ($Url) {
+    if (!function_exists('curl_init')){ 
+        die('CURL is not installed!');
+    }
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, $Url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    $output = curl_exec($ch);
+    curl_close($ch);
+    return $output;
+}
+
 ?>

--- a/steamauth/userInfo.php
+++ b/steamauth/userInfo.php
@@ -1,7 +1,7 @@
 <?php
 	include("settings.php");
     if (empty($_SESSION['steam_uptodate']) or $_SESSION['steam_uptodate'] == false or empty($_SESSION['steam_personaname'])) {
-        $url = file_get_contents("http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=".$steamauth['apikey']."&steamids=".$_SESSION['steamid']); 
+        $url = url_get_contents("http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=".$steamauth['apikey']."&steamids=".$_SESSION['steamid']); 
         $content = json_decode($url, true);
         $_SESSION['steam_steamid'] = $content['response']['players'][0]['steamid'];
         $_SESSION['steam_communityvisibilitystate'] = $content['response']['players'][0]['communityvisibilitystate'];
@@ -33,4 +33,6 @@
     $steamprofile['primaryclanid'] = $_SESSION['steam_primaryclanid'];
     $steamprofile['timecreated'] = $_SESSION['steam_timecreated'];
 ?>
+    
+
     


### PR DESCRIPTION
The previous version of **SteamAuthentication** is incompatible with many websites built on hosting providers, mainly due to the locked php.ini settings delegated to each server user.

In many of these cases, *php.ini* includes a line **allow_url_fopen=0** - this is due to a security risk with php functions being allowed to fetch remote files. Because of this, the *file_get_contents* function will not return any data, as seen in the error log entry below:

> PHP Warning:  file_get_contents(http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=0000&amp;steamids=0000) [<a href='function.file-get-contents'>function.file-get-contents</a>]: failed to open stream: no suitable wrapper could be found in /userInfo.php on line 4

Searching around provided [this StackOverflow answer](http://stackoverflow.com/a/3979882/601214) which provided a solution using cURL and a custom drop-in function. Using this solution solved the problem fully.

This pull request inserts the new function into *settings.php*, as well as replacing the function inside *userInfo.php*.
