### PR TITLE
Added support for passing _GET variables upon login

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,27 +25,53 @@ Add your API-Key from http://steamcommunity.com/dev/apikey
 
 Now in your file add the following at the top:
 
-    <?php
+```php
+<?php
 
-    require 'steamauth/steamauth.php';
-    
-    ?>
+require 'steamauth/steamauth.php';
+
+?>
+```
     
 And where you want the protected content to be:
 
-    <?php
-    if(!isset($_SESSION['steamid'])) {
+```php
+<?php
+if(!isset($_SESSION['steamid'])) {
 
-        steamlogin(); //login button
-    
-    }  else {
-    
-        include ('steamauth/userInfo.php'); //To access the $steamprofile array
-        //Protected content
+    echo steamlogin(); //login button
 
-        logoutbutton(); //Logout Button
-    }     
-    ?>
+}  else {
+
+    include ('steamauth/userInfo.php'); //To access the $steamprofile array
+    //Protected content
+
+    logoutbutton(); //Logout Button
+}     
+?>
+```
+
+You can also pass variables to ```steamlogin()``` to get them back once the user logs in by sending them as an array.
+
+```php
+<?php
+if(!isset($_SESSION['steamid'])) {
+
+    $vars = array('foo' => 'bar', 'some' => 'thing');
+    echo steamlogin($vars); //login button
+
+}  else {
+
+    include ('steamauth/userInfo.php'); //To access the $steamprofile array
+    //Protected content
+
+    echo $_GET['foo']; //Outputs bar
+    echo $_GET['some']; //Outputs thing
+
+    logoutbutton(); //Logout Button
+}     
+?>
+```
 
 By default, the logout button redirects to the root of the current folder, this can be changed in the settings.
 

--- a/example.php
+++ b/example.php
@@ -13,7 +13,7 @@
 if(!isset($_SESSION['steamid'])) {
 
     echo "welcome guest! please login \n \n";
-    steamlogin(); //login button
+    echo steamlogin(); //login button
     
 }  else {
     include ('steamauth/userInfo.php');

--- a/steamauth/steamauth.php
+++ b/steamauth/steamauth.php
@@ -7,7 +7,7 @@ function logoutbutton() {
     echo "<form action=\"steamauth/logout.php\" method=\"post\"><input value=\"Logout\" type=\"submit\" /></form>"; //logout button
 }
 
-function steamlogin($aditionalVars = '')
+function steamlogin($additionalVars = '')
 {
 try {
     require("settings.php");
@@ -24,7 +24,7 @@ try {
             header('Location: ' . $openid->authUrl());
         }
 
-    return "<form action=\"?login".(($aditionalVars === '') ? '' : '&'.http_build_query($aditionalVars))."\" method=\"post\"> <input type=\"image\" src=\"http://cdn.steamcommunity.com/public/images/signinthroughsteam/sits_".$button.".png\"></form>";
+    return "<form action=\"?login".(($additionalVars === '') ? '' : '&'.http_build_query($additionalVars))."\" method=\"post\"> <input type=\"image\" src=\"http://cdn.steamcommunity.com/public/images/signinthroughsteam/sits_".$button.".png\"></form>";
     }
 
      elseif($openid->mode == 'cancel') {

--- a/steamauth/steamauth.php
+++ b/steamauth/steamauth.php
@@ -7,12 +7,12 @@ function logoutbutton() {
     echo "<form action=\"steamauth/logout.php\" method=\"post\"><input value=\"Logout\" type=\"submit\" /></form>"; //logout button
 }
 
-function steamlogin()
+function steamlogin($aditionalVars = '')
 {
 try {
-	require("settings.php");
+    require("settings.php");
     $openid = new LightOpenID($steamauth['domainname']);
-    
+
     $button['small'] = "small";
     $button['large_no'] = "large_noborder";
     $button['large'] = "large_border";
@@ -23,8 +23,9 @@ try {
             $openid->identity = 'http://steamcommunity.com/openid';
             header('Location: ' . $openid->authUrl());
         }
-    echo "<form action=\"?login\" method=\"post\"> <input type=\"image\" src=\"http://cdn.steamcommunity.com/public/images/signinthroughsteam/sits_".$button.".png\"></form>";
-}
+
+    return "<form action=\"?login".(($aditionalVars === '') ? '' : '&'.$aditionalVars)."\" method=\"post\"> <input type=\"image\" src=\"http://cdn.steamcommunity.com/public/images/signinthroughsteam/sits_".$button.".png\"></form>";
+    }
 
      elseif($openid->mode == 'cancel') {
         echo 'User has canceled authentication!';
@@ -34,11 +35,14 @@ try {
                 $ptn = "/^http:\/\/steamcommunity\.com\/openid\/id\/(7[0-9]{15,25}+)$/";
                 preg_match($ptn, $id, $matches);
               
-                session_start();
                 $_SESSION['steamid'] = $matches[1]; 
-                 if (isset($steamauth['loginpage'])) {
-					header('Location: '.$steamauth['loginpage']);
-                 }
+
+                //Determine the return to page. We substract "login&"" to remove the login var from the URL.
+                //"file.php?login&foo=bar" would become "file.php?foo=bar"
+                $returnTo = str_replace('login&', '', $_GET['openid_return_to']);
+                //If it didn't change anything, it means that there's no additionals vars, so remove the login var so that we don't get redirected to Steam over and over.
+                if($returnTo === $_GET['openid_return_to']) $returnTo = str_replace('?login', '', $_GET['openid_return_to']);
+                header('Location: '.$returnTo);
         } else {
                 echo "User is not logged in.\n";
         }

--- a/steamauth/steamauth.php
+++ b/steamauth/steamauth.php
@@ -24,7 +24,7 @@ try {
             header('Location: ' . $openid->authUrl());
         }
 
-    return "<form action=\"?login".(($aditionalVars === '') ? '' : '&'.$aditionalVars)."\" method=\"post\"> <input type=\"image\" src=\"http://cdn.steamcommunity.com/public/images/signinthroughsteam/sits_".$button.".png\"></form>";
+    return "<form action=\"?login".(($aditionalVars === '') ? '' : '&'.http_build_query($aditionalVars))."\" method=\"post\"> <input type=\"image\" src=\"http://cdn.steamcommunity.com/public/images/signinthroughsteam/sits_".$button.".png\"></form>";
     }
 
      elseif($openid->mode == 'cancel') {


### PR DESCRIPTION
Hello again. I'm still developing my project wich I've [uploaded to GitHub](https://github.com/MeLlamoPablo/NotaStacks) (in case you wanted to check it out if you were interested. And don't worry, I'll credit you when it's done :P). This time I needed to pass variables to be retrieved after the user logs in, and the framework currently didn't have support for that. So, I've added it, and I've uploaded it to my fork, in case you wanted to consider merging it. Here's how it works.

The ```steamlogin()``` function works as usual. The only change is that you now have to put ```echo``` before calling it: the function itself won't echo the button anymore, you have to manually do it. Why? Felxibility. Sometimes you don't need the button to be ```echo```ed immediatly, but stored it in a variable to maybe pass it as a parameter to a method. For example, in [my script](https://github.com/MeLlamoPablo/NotaStacks/blob/master/menu.php#L27) I pass the button as a parameter to the method ```Modal::__construct()```. The class will create a [Bootstrap Modal](http://getbootstrap.com/javascript/#modals) later, and include the button on it. If ```steamlogin()``` did ```echo``` instead of ```return``` I'd need to modify my entire class; this way is much more convenient.

So, any app that ran
```php
steamlogin();
```
should now run
```php
echo steamlogin();
```
And now, the most important change. If you want to pass variables to be returned after the login, you'd do the following:
```php
echo steamlogin("foo=1&bar=2");
```
Notice that you don't have to put any ```?```s and ```&```s at the beginning.
In that case, you can use ```$_GET['foo']``` and ```$_GET['bar']``` on your login page (set on the settings), and they will be set to ```1``` and ```2```, respectively. Assuming that your return URL is ```http://website.com/index.php```, the user will be redirected to ```http://website.com/index.php?foo=1&bar=2``` after loging in successfully on Steam.

One last change: the line ```session_start()``` at line 37 on the old file was removed because it's already called at the beginning, so I believe that there's no point on calling it again (In fact, it gives you a warning)

Thanks for your time, and have a nice day!