### PR TITLE
URL-Generation fix, remove die()

### DIFF
--- a/steamauth/settings.php
+++ b/steamauth/settings.php
@@ -1,5 +1,5 @@
 <?php
-$steamauth['apikey'] = ""; // Your Steam WebAPI-Key found at http://steamcommunity.com/dev/apikey
+$steamauth['apikey'] = "1D8373E5C0CB0ABBA50FE893F5019811"; // Your Steam WebAPI-Key found at http://steamcommunity.com/dev/apikey
 $steamauth['domainname'] = ""; // The main URL of your website displayed in the login page
 $steamauth['buttonstyle'] = ""; // Style of the login button [small|large_no|large]
 $steamauth['logoutpage'] = ""; // Page to redirect to after a successfull logout (from the directory the SteamAuth-folder is located in) - NO slash at the beginning!

--- a/steamauth/settings.php
+++ b/steamauth/settings.php
@@ -1,5 +1,5 @@
 <?php
-$steamauth['apikey'] = "1D8373E5C0CB0ABBA50FE893F5019811"; // Your Steam WebAPI-Key found at http://steamcommunity.com/dev/apikey
+$steamauth['apikey'] = ""; // Your Steam WebAPI-Key found at http://steamcommunity.com/dev/apikey
 $steamauth['domainname'] = ""; // The main URL of your website displayed in the login page
 $steamauth['buttonstyle'] = ""; // Style of the login button [small|large_no|large]
 $steamauth['logoutpage'] = ""; // Page to redirect to after a successfull logout (from the directory the SteamAuth-folder is located in) - NO slash at the beginning!

--- a/steamauth/steamauth.php
+++ b/steamauth/steamauth.php
@@ -7,7 +7,7 @@ function logoutbutton() {
     echo "<form action=\"steamauth/logout.php\" method=\"post\"><input value=\"Logout\" type=\"submit\" /></form>"; //logout button
 }
 
-function steamlogin($additionalVars = '')
+function steamlogin()
 {
 try {
     require("settings.php");
@@ -24,7 +24,7 @@ try {
             header('Location: ' . $openid->authUrl());
         }
 
-    return "<form action=\"?login".(($additionalVars === '') ? '' : '&'.http_build_query($additionalVars))."\" method=\"post\"> <input type=\"image\" src=\"http://cdn.steamcommunity.com/public/images/signinthroughsteam/sits_".$button.".png\"></form>";
+    return "<form action=\"?login\" method=\"post\"> <input type=\"image\" src=\"http://cdn.steamcommunity.com/public/images/signinthroughsteam/sits_".$button.".png\"></form>";
     }
 
      elseif($openid->mode == 'cancel') {

--- a/steamauth/userInfo.php
+++ b/steamauth/userInfo.php
@@ -1,13 +1,8 @@
 <?php
-
-    //We make sure that the user has logged in before attempting to use the Steam API to avoid warnings and wasted resources.
-    if(isset($_SESSION['steamid'])){
-
+    if(!$_SESSION['steamid'] == ""){
     	include("settings.php");
         if (empty($_SESSION['steam_uptodate']) or $_SESSION['steam_uptodate'] == false or empty($_SESSION['steam_personaname'])) {
-            //We mute alerts from the following line because we do not want to give away our API key in case file_get_contents() throws a warning.
             @ $url = file_get_contents("http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=".$steamauth['apikey']."&steamids=".$_SESSION['steamid']);
-            if($url === FALSE) { die('Error: failed to fetch content form Steam. It may be down. Please, try again later.'); }
             $content = json_decode($url, true);
             $_SESSION['steam_steamid'] = $content['response']['players'][0]['steamid'];
             $_SESSION['steam_communityvisibilitystate'] = $content['response']['players'][0]['communityvisibilitystate'];
@@ -28,7 +23,6 @@
             $_SESSION['steam_timecreated'] = $content['response']['players'][0]['timecreated'];
             $_SESSION['steam_uptodate'] = true;
         }
-        
         $steamprofile['steamid'] = $_SESSION['steam_steamid'];
         $steamprofile['communityvisibilitystate'] = $_SESSION['steam_communityvisibilitystate'];
         $steamprofile['profilestate'] = $_SESSION['steam_profilestate'];


### PR DESCRIPTION
The die() in userInfo.php made it possible for the complete page to stop
working without the option for displaying a error message. Librarys
should never die() in cases where it is out of the control of the
developer.
