### PR TITLE
Clearing up instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Upload the `steamauth` folder.
 Open up `settings.php` and change `domainname` to your domain name.
 Add your API-Key from http://steamcommunity.com/dev/apikey
 
-Now in the page that you would like to use the steamauth library add the following at the top:
+Now in the page that you would like to use the steamauth library, add the following at the top:
 
     <?php
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Upload the `steamauth` folder.
 Open up `settings.php` and change `domainname` to your domain name.
 Add your API-Key from http://steamcommunity.com/dev/apikey
 
-Now in your file add the following at the top:
+Now in the page that you would like to use the steamauth library add the following at the top:
 
     <?php
 


### PR DESCRIPTION
on error #106, they added the    
`    <?php

    require 'steamauth/steamauth.php';
    
    ?>`
code because it said: 

> Now in your file add the following at the top<

and i think that they thought that it meant in the settings file.

(sorry for all of the pull request and that i did not combine them into one.)
( closes #106 )