### PR TITLE
Updating User Information | Include to Require

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ loginbutton("large");
     
 ##Using Profile Variables
 
-I have create a userInfo.php file which creates an array of ready to use variables that includes profile information of the steam user that has logged in:
+I have created a userInfo.php file which creates an array of ready to use variables that includes profile information of the steam user that has logged in:
 
 * `$steamprofile['steamid']` - The users unique SteamID
 * `$steamprofile['communityvisibilitystate']` - This represents whether the profile is visible or not.
@@ -93,9 +93,16 @@ I have create a userInfo.php file which creates an array of ready to use variabl
 * `$steamprofile['realname']` - The users "real" name
 * `$steamprofile['primaryclanid']` - The users primary group
 * `$steamprofile['timecreated']` - When the account was created
-* `$_SESSION['steam_uptodate']` - Unset to refresh data from Steam
+* `$_SESSION['steam_uptodate']` - When profile information was last updated in unix time - Unset to refresh data from Steam
 
 Please note that some of these variables may be unavailable for some users as it depends on their privacy settings. 
+
+#### Update User Information
+
+To get updated steam profile use 
+html: `<a href="?update">update</a>` - recommended
+-OR-
+php: `$_GET['update']=true;` - this must be set before `require 'steamauth/steamauth.php';`
 
 * For more help on laying out the document or using the $steamprofile variable see the example.php file!
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ I have created a userInfo.php file which creates an array of ready to use variab
 * `$steamprofile['realname']` - The users "real" name
 * `$steamprofile['primaryclanid']` - The users primary group
 * `$steamprofile['timecreated']` - When the account was created
-* `$_SESSION['steam_uptodate']` - When profile information was last updated in unix time - Unset to refresh data from Steam
+* `$_SESSION['steam_uptodate']` - When profile information was last updated in unix time
 
 Please note that some of these variables may be unavailable for some users as it depends on their privacy settings. 
 
@@ -103,6 +103,20 @@ To get updated steam profile use
 html: `<a href="?update">update</a>` - recommended
 -OR-
 php: `$_GET['update']=true;` - this must be set before `require 'steamauth/steamauth.php';`
+
+###### automatically update user info if older than specified time when they next visit your site
+
+change line 67 of `steamauth.php` 
+From:
+```php
+if (isset($_GET['update'])){ 
+```
+To:
+```php
+if (isset($_GET['update']) || !empty($_SESSION['steam_uptodate']) && $_SESSION['steam_uptodate']+(24*60*60) < time()){ 
+```
+ps: example shown would update if older than 24 hours
+pss: the numbers in the brackets `$_SESSION['steam_uptodate']+(24*60*60)` should be the maximum number of seconds before updating user info
 
 * For more help on laying out the document or using the $steamprofile variable see the example.php file!
 

--- a/demo.php
+++ b/demo.php
@@ -52,58 +52,49 @@ if(!isset($_SESSION['steamid'])) {
 			</tr>
 			<tr>
 				<td>$steamprofile['steamid']</td>
-				<td><?=$steamprofile['steamid']?>
-				</td>
+				<td><?=$steamprofile['steamid']?></td>
 				<td>SteamID64 of the user</td>
 			</tr>
 			<tr>
 				<td>$steamprofile['communityvisibilitystate']</td>
-				<td><?=$steamprofile['communityvisibilitystate']?>
-				</td>
+				<td><?=$steamprofile['communityvisibilitystate']?></td>
 				<td>1 - Account not visible; 3 - Account is public (Depends on the relationship of your account to the others)</td>
 			</tr>
 			<tr>
 				<td>$steamprofile['profilestate']</td>
-				<td><?=$steamprofile['profilestate']?>
-				</td>
+				<td><?=$steamprofile['profilestate']?></td>
 				<td>1 - The user has a Steam Community profile; 0 - if not</td>
 			</tr>
 			<tr>
 				<td>$steamprofile['personaname']</td>
-				<td><?=$steamprofile['personaname']?>
-				</td>
+				<td><?=$steamprofile['personaname']?></td>
 				<td>Public name of the user</td>
 			</tr>
 			<tr>
 				<td>$steamprofile['lastlogoff']</td>
-				<td><?=$steamprofile['lastlogoff']?>
-				</td>
+				<td><?=$steamprofile['lastlogoff']?></td>
 				<td>
 					<a href='http://www.unixtimestamp.com/' target='_blank'>Unix timestamp</a> of the user's last logoff
 				</td>
 			</tr>
 			<tr>
 				<td>$steamprofile['profileurl']</td>
-				<td><?=$steamprofile['profileurl']?>
-				</td>
+				<td><?=$steamprofile['profileurl']?></td>
 				<td>Link to the user's profile</td>
 			</tr>
 			<tr>
 				<td>$steamprofile['personastate']</td>
-				<td><?=$steamprofile['personastate']?>
-				</td>
+				<td><?=$steamprofile['personastate']?></td>
 				<td>0 - Offline, 1 - Online, 2 - Busy, 3 - Away, 4 - Snooze, 5 - looking to trade, 6 - looking to play</td>
 			</tr>
 			<tr>
 				<td>$steamprofile['realname']</td>
-				<td><?=$steamprofile['realname']?>
-				</td>
+				<td><?=$steamprofile['realname']?></td>
 				<td>"Real" name</td>
 			</tr>
 			<tr>
 				<td>$steamprofile['primaryclanid']</td>
-				<td><?=$steamprofile['primaryclanid']?>
-				</td>
+				<td><?=$steamprofile['primaryclanid']?></td>
 				<td>The ID of the user's primary group</td>
 			</tr>
 			<tr>
@@ -115,23 +106,33 @@ if(!isset($_SESSION['steamid'])) {
 				</td>
 			</tr>
 			<tr>
+				<td>$steamprofile['steam_uptodate']</td>
+				<td><?=$steamprofile['steam_uptodate']?></td>
+				<td>
+					<a href='http://www.unixtimestamp.com/' target='_blank'>Unix timestamp</a> for the time the user's account information was last updated
+				</td>
+			</tr>
+			<tr>
 				<td>$steamprofile['avatar']</td>
-				<td><img src='<?=$steamprofile['avatar']?>'><br>
-				<?=$steamprofile['avatar']?>
+				<td>
+					<img src='<?=$steamprofile['avatar']?>'><br>
+					<?=$steamprofile['avatar']?>
 				</td>
 				<td>Address of the user's 32x32px avatar</td>
 			</tr>
 			<tr>
 				<td>$steamprofile['avatarmedium']</td>
-				<td><img src='<?=$steamprofile['avatarmedium']?>'><br>
-				<?=$steamprofile['avatarmedium']?>
+				<td>
+					<img src='<?=$steamprofile['avatarmedium']?>'><br>
+					<?=$steamprofile['avatarmedium']?>
 				</td>
 				<td>Address of the user's 64x64px avatar</td>
 			</tr>
 			<tr>
 				<td>$steamprofile['avatarfull']</td>
-				<td><img src='<?=$steamprofile['avatarfull']?>'><br>
-				<?=$steamprofile['avatarfull']?>
+				<td>
+					<img src='<?=$steamprofile['avatarfull']?>'><br>
+					<?=$steamprofile['avatarfull']?>
 				</td>
 				<td>Address of the user's 184x184px avatar</td>
 			</tr>

--- a/demo.php
+++ b/demo.php
@@ -106,8 +106,8 @@ if(!isset($_SESSION['steamid'])) {
 				</td>
 			</tr>
 			<tr>
-				<td>$_SESSION['steam_uptodate']</td>
-				<td><?=$_SESSION['steam_uptodate']?></td>
+				<td>$steamprofile['uptodate']</td>
+				<td><?=$steamprofile['uptodate']?></td>
 				<td>
 					<a href='http://www.unixtimestamp.com/' target='_blank'>Unix timestamp</a> for the time the user's account information was last updated
 				</td>

--- a/demo.php
+++ b/demo.php
@@ -106,8 +106,8 @@ if(!isset($_SESSION['steamid'])) {
 				</td>
 			</tr>
 			<tr>
-				<td>$steamprofile['steam_uptodate']</td>
-				<td><?=$steamprofile['steam_uptodate']?></td>
+				<td>$_SESSION['steam_uptodate']</td>
+				<td><?=$_SESSION['steam_uptodate']?></td>
 				<td>
 					<a href='http://www.unixtimestamp.com/' target='_blank'>Unix timestamp</a> for the time the user's account information was last updated
 				</td>

--- a/steamauth/SteamConfig.php
+++ b/steamauth/SteamConfig.php
@@ -4,12 +4,10 @@ $steamauth['apikey'] = ""; // Your Steam WebAPI-Key found at http://steamcommuni
 $steamauth['domainname'] = ""; // The main URL of your website displayed in the login page
 $steamauth['logoutpage'] = ""; // Page to redirect to after a successfull logout (from the directory the SteamAuth-folder is located in) - NO slash at the beginning!
 $steamauth['loginpage'] = ""; // Page to redirect to after a successfull login (from the directory the SteamAuth-folder is located in) - NO slash at the beginning!
-$steamauth['updateinterval'] = ""; // How often to update users steam information ex: 24*60*60 = 24 hours/1 day
 
 // System stuff
 if (empty($steamauth['apikey'])) {die("<div style='display: block; width: 100%; background-color: red; text-align: center;'>SteamAuth:<br>Please supply an API-Key!</div>");}
 if (empty($steamauth['domainname'])) {$steamauth['domainname'] = $_SERVER['SERVER_NAME'];}
 if (empty($steamauth['logoutpage'])) {$steamauth['logoutpage'] = $_SERVER['PHP_SELF'];}
 if (empty($steamauth['loginpage'])) {$steamauth['loginpage'] = $_SERVER['PHP_SELF'];}
-if (empty($steamauth['updateinterval'])) {$steamauth['updateinterval'] = 24*60*60;}
 ?>

--- a/steamauth/SteamConfig.php
+++ b/steamauth/SteamConfig.php
@@ -4,10 +4,12 @@ $steamauth['apikey'] = ""; // Your Steam WebAPI-Key found at http://steamcommuni
 $steamauth['domainname'] = ""; // The main URL of your website displayed in the login page
 $steamauth['logoutpage'] = ""; // Page to redirect to after a successfull logout (from the directory the SteamAuth-folder is located in) - NO slash at the beginning!
 $steamauth['loginpage'] = ""; // Page to redirect to after a successfull login (from the directory the SteamAuth-folder is located in) - NO slash at the beginning!
+$steamauth['updateinterval'] = ""; // How often to update users steam information ex: 24*60*60 = 24 hours/1 day
 
 // System stuff
 if (empty($steamauth['apikey'])) {die("<div style='display: block; width: 100%; background-color: red; text-align: center;'>SteamAuth:<br>Please supply an API-Key!</div>");}
 if (empty($steamauth['domainname'])) {$steamauth['domainname'] = $_SERVER['SERVER_NAME'];}
 if (empty($steamauth['logoutpage'])) {$steamauth['logoutpage'] = $_SERVER['PHP_SELF'];}
 if (empty($steamauth['loginpage'])) {$steamauth['loginpage'] = $_SERVER['PHP_SELF'];}
+if (empty($steamauth['updateinterval'])) {$steamauth['updateinterval'] = 24*60*60;}
 ?>

--- a/steamauth/steamauth.php
+++ b/steamauth/steamauth.php
@@ -1,10 +1,9 @@
 <?php
 ob_start();
 session_start();
-require 'SteamConfig.php';
 
 function logoutbutton() {
-    echo "<form action='' method='get'><button name='logout' type='submit'>Logout</button></form>"; //logout button
+	echo "<form action='' method='get'><button name='logout' type='submit'>Logout</button></form>"; //logout button
 }
 
 function loginbutton($buttonstyle = "large_no") {
@@ -19,6 +18,7 @@ function loginbutton($buttonstyle = "large_no") {
 if (isset($_GET['login'])){
 	require 'openid.php';
 	try {
+		require 'SteamConfig.php';
 		$openid = new LightOpenID($steamauth['domainname']);
 		
 		if(!$openid->mode) {
@@ -31,12 +31,12 @@ if (isset($_GET['login'])){
 				$id = $openid->identity;
 				$ptn = "/^http:\/\/steamcommunity\.com\/openid\/id\/(7[0-9]{15,25}+)$/";
 				preg_match($ptn, $id, $matches);
-			  
-				$_SESSION['steamid'] = $matches[1]; 
+				
+				$_SESSION['steamid'] = $matches[1];
 				if (!headers_sent()) {
 					header('Location: '.$steamauth['loginpage']);
 					exit;
-                } else {
+				} else {
 					?>
 					<script type="text/javascript">
 						window.location.href="<?=$steamauth['loginpage']?>";
@@ -46,7 +46,7 @@ if (isset($_GET['login'])){
 					</noscript>
 					<?php
 					exit;
-                }
+				}
 			} else {
 				echo "User is not logged in.\n";
 			}
@@ -57,13 +57,14 @@ if (isset($_GET['login'])){
 }
 
 if (isset($_GET['logout'])){
+	require 'SteamConfig.php';
 	session_unset();
 	session_destroy();
 	header('Location: '.$steamauth['logoutpage']);
 	exit;
 }
 
-if (isset($_GET['update']) || !empty($_SESSION['steam_uptodate']) && $_SESSION['steam_uptodate']+$steamauth['updateinterval'] < time()){ 
+if (isset($_GET['update'])){
 	unset($_SESSION['steam_uptodate']);
 	require 'userInfo.php';
 	header('Location: '.$_SERVER['PHP_SELF']);

--- a/steamauth/steamauth.php
+++ b/steamauth/steamauth.php
@@ -1,7 +1,6 @@
 <?php
 ob_start();
 session_start();
-require 'openid.php';
 
 function logoutbutton() {
     echo "<form action='' method='get'><button name='logout' type='submit'>Logout</button></form>"; //logout button
@@ -17,6 +16,7 @@ function loginbutton($buttonstyle = "large_no") {
 }
 
 if (isset($_GET['login'])){
+	require 'openid.php';
 	try {
 		require 'SteamConfig.php';
 		$openid = new LightOpenID($steamauth['domainname']);

--- a/steamauth/steamauth.php
+++ b/steamauth/steamauth.php
@@ -1,7 +1,7 @@
 <?php
 ob_start();
 session_start();
-require ('openid.php');
+require 'openid.php';
 
 function logoutbutton() {
     echo "<form action='' method='get'><button name='logout' type='submit'>Logout</button></form>"; //logout button
@@ -18,9 +18,8 @@ function loginbutton($buttonstyle = "large_no") {
 
 if (isset($_GET['login'])){
 	try {
-		require("SteamConfig.php");
+		require 'SteamConfig.php';
 		$openid = new LightOpenID($steamauth['domainname']);
-		
 		
 		if(!$openid->mode) {
 			$openid->identity = 'http://steamcommunity.com/openid';
@@ -35,16 +34,19 @@ if (isset($_GET['login'])){
 			  
 				$_SESSION['steamid'] = $matches[1]; 
 				if (!headers_sent()) {
-                    			header('Location: '.$steamauth['loginpage']);
-                    			exit;
-                		} else {
-					echo '<script type="text/javascript">';
-                    			echo 'window.location.href="'.$steamauth['loginpage'].'";';
-                    			echo '</script>';
-                    			echo '<noscript>';
-                    			echo '<meta http-equiv="refresh" content="0;url='.$steamauth['loginpage'].'" />';
-                    			echo '</noscript>'; exit;
-                		}
+					header('Location: '.$steamauth['loginpage']);
+					exit;
+                } else {
+					?>
+					<script type="text/javascript">
+						window.location.href="<?=$steamauth['loginpage']?>";
+					</script>
+					<noscript>
+						<meta http-equiv="refresh" content="0;url=<?=$steamauth['loginpage']?>" />
+					</noscript>
+					<?php
+					exit;
+                }
 			} else {
 				echo "User is not logged in.\n";
 			}
@@ -55,15 +57,17 @@ if (isset($_GET['login'])){
 }
 
 if (isset($_GET['logout'])){
-	include("SteamConfig.php");
+	require 'SteamConfig.php';
 	session_unset();
 	session_destroy();
 	header('Location: '.$steamauth['logoutpage']);
+	exit;
 }
 
-if (isset($_GET['update'])){
+if (isset($_GET['update']) || !empty($_SESSION['steam_uptodate']) && $_SESSION['steam_uptodate']+(24*60*60) < time()){ 
 	unset($_SESSION['steam_uptodate']);
-	include("userinfo.php");
+	require 'userInfo.php';
 	header('Location: '.$_SERVER['PHP_SELF']);
+	exit;
 }
 ?>

--- a/steamauth/steamauth.php
+++ b/steamauth/steamauth.php
@@ -1,6 +1,7 @@
 <?php
 ob_start();
 session_start();
+require 'SteamConfig.php';
 
 function logoutbutton() {
     echo "<form action='' method='get'><button name='logout' type='submit'>Logout</button></form>"; //logout button
@@ -18,7 +19,6 @@ function loginbutton($buttonstyle = "large_no") {
 if (isset($_GET['login'])){
 	require 'openid.php';
 	try {
-		require 'SteamConfig.php';
 		$openid = new LightOpenID($steamauth['domainname']);
 		
 		if(!$openid->mode) {
@@ -57,14 +57,13 @@ if (isset($_GET['login'])){
 }
 
 if (isset($_GET['logout'])){
-	require 'SteamConfig.php';
 	session_unset();
 	session_destroy();
 	header('Location: '.$steamauth['logoutpage']);
 	exit;
 }
 
-if (isset($_GET['update']) || !empty($_SESSION['steam_uptodate']) && $_SESSION['steam_uptodate']+(24*60*60) < time()){ 
+if (isset($_GET['update']) || !empty($_SESSION['steam_uptodate']) && $_SESSION['steam_uptodate']+$steamauth['updateinterval'] < time()){ 
 	unset($_SESSION['steam_uptodate']);
 	require 'userInfo.php';
 	header('Location: '.$_SERVER['PHP_SELF']);

--- a/steamauth/userInfo.php
+++ b/steamauth/userInfo.php
@@ -36,5 +36,6 @@ $steamprofile['personastate'] = $_SESSION['steam_personastate'];
 $steamprofile['realname'] = $_SESSION['steam_realname'];
 $steamprofile['primaryclanid'] = $_SESSION['steam_primaryclanid'];
 $steamprofile['timecreated'] = $_SESSION['steam_timecreated'];
+$steamprofile['uptodate'] = $_SESSION['steam_uptodate'];
 ?>
     

--- a/steamauth/userInfo.php
+++ b/steamauth/userInfo.php
@@ -1,40 +1,40 @@
 <?php
-	include("SteamConfig.php");
-    if (empty($_SESSION['steam_uptodate']) or empty($_SESSION['steam_personaname'])) {
-        $url = file_get_contents("http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=".$steamauth['apikey']."&steamids=".$_SESSION['steamid']); 
-        $content = json_decode($url, true);
-        $_SESSION['steam_steamid'] = $content['response']['players'][0]['steamid'];
-        $_SESSION['steam_communityvisibilitystate'] = $content['response']['players'][0]['communityvisibilitystate'];
-        $_SESSION['steam_profilestate'] = $content['response']['players'][0]['profilestate'];
-        $_SESSION['steam_personaname'] = $content['response']['players'][0]['personaname'];
-        $_SESSION['steam_lastlogoff'] = $content['response']['players'][0]['lastlogoff'];
-        $_SESSION['steam_profileurl'] = $content['response']['players'][0]['profileurl'];
-        $_SESSION['steam_avatar'] = $content['response']['players'][0]['avatar'];
-        $_SESSION['steam_avatarmedium'] = $content['response']['players'][0]['avatarmedium'];
-        $_SESSION['steam_avatarfull'] = $content['response']['players'][0]['avatarfull'];
-        $_SESSION['steam_personastate'] = $content['response']['players'][0]['personastate'];
-        if (isset($content['response']['players'][0]['realname'])) { 
-	           $_SESSION['steam_realname'] = $content['response']['players'][0]['realname'];
-	       } else {
-	           $_SESSION['steam_realname'] = "Real name not given";
-        }
-        $_SESSION['steam_primaryclanid'] = $content['response']['players'][0]['primaryclanid'];
-        $_SESSION['steam_timecreated'] = $content['response']['players'][0]['timecreated'];
-        $_SESSION['steam_uptodate'] = true;
-    }
-    
-    $steamprofile['steamid'] = $_SESSION['steam_steamid'];
-    $steamprofile['communityvisibilitystate'] = $_SESSION['steam_communityvisibilitystate'];
-    $steamprofile['profilestate'] = $_SESSION['steam_profilestate'];
-    $steamprofile['personaname'] = $_SESSION['steam_personaname'];
-    $steamprofile['lastlogoff'] = $_SESSION['steam_lastlogoff'];
-    $steamprofile['profileurl'] = $_SESSION['steam_profileurl'];
-    $steamprofile['avatar'] = $_SESSION['steam_avatar'];
-    $steamprofile['avatarmedium'] = $_SESSION['steam_avatarmedium'];
-    $steamprofile['avatarfull'] = $_SESSION['steam_avatarfull'];
-    $steamprofile['personastate'] = $_SESSION['steam_personastate'];
-    $steamprofile['realname'] = $_SESSION['steam_realname'];
-    $steamprofile['primaryclanid'] = $_SESSION['steam_primaryclanid'];
-    $steamprofile['timecreated'] = $_SESSION['steam_timecreated'];
+if (empty($_SESSION['steam_uptodate']) or empty($_SESSION['steam_personaname'])) {
+	require 'SteamConfig.php';
+	$url = file_get_contents("http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=".$steamauth['apikey']."&steamids=".$_SESSION['steamid']); 
+	$content = json_decode($url, true);
+	$_SESSION['steam_steamid'] = $content['response']['players'][0]['steamid'];
+	$_SESSION['steam_communityvisibilitystate'] = $content['response']['players'][0]['communityvisibilitystate'];
+	$_SESSION['steam_profilestate'] = $content['response']['players'][0]['profilestate'];
+	$_SESSION['steam_personaname'] = $content['response']['players'][0]['personaname'];
+	$_SESSION['steam_lastlogoff'] = $content['response']['players'][0]['lastlogoff'];
+	$_SESSION['steam_profileurl'] = $content['response']['players'][0]['profileurl'];
+	$_SESSION['steam_avatar'] = $content['response']['players'][0]['avatar'];
+	$_SESSION['steam_avatarmedium'] = $content['response']['players'][0]['avatarmedium'];
+	$_SESSION['steam_avatarfull'] = $content['response']['players'][0]['avatarfull'];
+	$_SESSION['steam_personastate'] = $content['response']['players'][0]['personastate'];
+	if (isset($content['response']['players'][0]['realname'])) { 
+		   $_SESSION['steam_realname'] = $content['response']['players'][0]['realname'];
+	   } else {
+		   $_SESSION['steam_realname'] = "Real name not given";
+	}
+	$_SESSION['steam_primaryclanid'] = $content['response']['players'][0]['primaryclanid'];
+	$_SESSION['steam_timecreated'] = $content['response']['players'][0]['timecreated'];
+	$_SESSION['steam_uptodate'] = time();
+}
+
+$steamprofile['steamid'] = $_SESSION['steam_steamid'];
+$steamprofile['communityvisibilitystate'] = $_SESSION['steam_communityvisibilitystate'];
+$steamprofile['profilestate'] = $_SESSION['steam_profilestate'];
+$steamprofile['personaname'] = $_SESSION['steam_personaname'];
+$steamprofile['lastlogoff'] = $_SESSION['steam_lastlogoff'];
+$steamprofile['profileurl'] = $_SESSION['steam_profileurl'];
+$steamprofile['avatar'] = $_SESSION['steam_avatar'];
+$steamprofile['avatarmedium'] = $_SESSION['steam_avatarmedium'];
+$steamprofile['avatarfull'] = $_SESSION['steam_avatarfull'];
+$steamprofile['personastate'] = $_SESSION['steam_personastate'];
+$steamprofile['realname'] = $_SESSION['steam_realname'];
+$steamprofile['primaryclanid'] = $_SESSION['steam_primaryclanid'];
+$steamprofile['timecreated'] = $_SESSION['steam_timecreated'];
 ?>
     


### PR DESCRIPTION
## REAMDE.md
- Added information on how to update user info
- example on how to update user info if older than 24 hours

## userInfo.php
- Changed `$_SESSION['steam_uptodate']` to be timestamp `time()` rather than true (can be used to update user info if older than specified time)
- Removed 1 level of indentation
- changed include to require as it is required in order to function correctly
- moved require inside `if` as it is not needed otherwise

## steamauth.php
- changed includes to requires as they are required in order to function
correctly
- [removed brackets from require](http://php.net/manual/en/function.require.php#75875)
- inside if `headers_sent()` closed and reopened php tags rather than echoing the html
- added `exit;` to update and logout
- moved `require 'openid.php';` inside of `if (isset($_GET['login'])){` as this is the only time it is needed

## demo.php
- add `$steamprofile['steam_uptodate'] ` to demo.php page
- close `<td>` on same line

_Note: updating this list as changes happen_