### PR TITLE
Modify steamauth.php for support of multiple vars in url?

### DIFF
--- a/steamauth/steamauth.php
+++ b/steamauth/steamauth.php
@@ -33,16 +33,24 @@ if (isset($_GET['login'])){
 				preg_match($ptn, $id, $matches);
 				
 				$_SESSION['steamid'] = $matches[1];
+				
+				if (isset($_GET['urlparam'])){
+					$returnpage = $steamauth['loginpage'].'?param='.$_GET['urlparam'];
+				}
+				else{
+					$returnpage = $steamauth['loginpage'];
+				}
+				
 				if (!headers_sent()) {
-					header('Location: '.$steamauth['loginpage']);
+					header('Location: '.$returnpage);
 					exit;
 				} else {
 					?>
 					<script type="text/javascript">
-						window.location.href="<?=$steamauth['loginpage']?>";
+						window.location.href="<?=$returnpage?>";
 					</script>
 					<noscript>
-						<meta http-equiv="refresh" content="0;url=<?=$steamauth['loginpage']?>" />
+						<meta http-equiv="refresh" content="0;url=<?=$returnpage?>" />
 					</noscript>
 					<?php
 					exit;


### PR DESCRIPTION
Heard many people were struggling with this so made a small modification that gives users the opportunity to let their visitors login from pages with variables in the url. I made this optional, so it also works without any vars. Users would only have to change the GET involved in the url and change the var name in the $returnpage.