### PR TITLE
Removed spaces after PHP close tag

### DIFF
--- a/steamauth/userInfo.php
+++ b/steamauth/userInfo.php
@@ -40,4 +40,3 @@ $steamprofile['uptodate'] = $_SESSION['steam_uptodate'];
 
 // Version 4.0
 ?>
-    


### PR DESCRIPTION
Blank line and spaces at the end of the file caused errors to be thrown such as: Warning: require(SteamConfig.php): failed to open stream: No such file or directory in ...

Removing the line at the end of the file fixes this.